### PR TITLE
Fix getCoordinates condition

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,7 +20,7 @@ export function blacklist(input: PlainObject, exclude: string | Array<string>): 
 }
 
 export function getCoordinates(e: MouseEvent | TouchEvent) {
-  if (e instanceof TouchEvent && window.TouchEvent) {
+  if (window.TouchEvent && e instanceof TouchEvent) {
     const touch = e.touches[0];
 
     return {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,7 +20,7 @@ export function blacklist(input: PlainObject, exclude: string | Array<string>): 
 }
 
 export function getCoordinates(e: MouseEvent | TouchEvent) {
-  if (e instanceof TouchEvent) {
+  if (e instanceof TouchEvent && window.TouchEvent) {
     const touch = e.touches[0];
 
     return {
@@ -29,9 +29,10 @@ export function getCoordinates(e: MouseEvent | TouchEvent) {
     };
   }
 
-  // @ts-ignore
   return {
+    // @ts-ignore clientX only exists on MouseEvent
     x: e.clientX,
+    // @ts-ignore clientY only exists on MouseEvent
     y: e.clientY,
   };
 }


### PR DESCRIPTION
Touch events are not fully compatible with all desktop browsers (https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/TouchEvent), and will throw a "TouchEvent is not defined" error if attempts are made to use them where not defined. The issue can be reproduced by attempting to drag the slider on a browser such as Firefox.

A simple fix is to add an additional check before checking if an event is an instance of TouchEvent, namely if window.TouchEvent is defined. This PR simply employs that fix (and a slight change to the @ts-ignore line since it started giving me some grief only being above the return statement).